### PR TITLE
Add apache configuration for yii apps

### DIFF
--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -24,6 +24,27 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 
+# Add Yii2 config
+RUN { \
+        echo '<Directory /var/www/html/web>'; \
+        echo '  Require all granted'; \
+        echo '  # use mod_rewrite for pretty URL support'; \
+        echo '  RewriteEngine on'; \
+        echo '  # If a directory or a file exists, use the request directly'; \
+        echo '  RewriteCond %{REQUEST_FILENAME} !-f'; \
+        echo '  RewriteCond %{REQUEST_FILENAME} !-d'; \
+        echo '  # Exclude static file types'; \
+        echo '  RewriteCond %{REQUEST_URI} !\.(css|gif|ico|jpg|js|map|png|svg|ttf|woff|woff2)$'; \
+        echo '  # Otherwise forward the request to index.php'; \
+        echo '  RewriteRule . index.php'; \
+        echo '</Directory>'; \
+    } | tee /etc/apache2/conf-available/yii2-php.conf \
+    && sed -i 's#DocumentRoot.*#DocumentRoot /var/www/html/web#' /etc/apache2/sites-available/000-default.conf \
+    && sed -i 's/ServerTokens OS/ServerTokens Prod/' /etc/apache2/conf-available/security.conf \
+    && sed -i 's/ServerSignature On/ServerSignature Off/' /etc/apache2/conf-available/security.conf \
+    && a2enconf yii2-php \
+    && a2enmod rewrite
+
 # Install composer
 COPY install-composer /install-composer
 RUN /install-composer && rm /install-composer

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -24,6 +24,27 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 
+# Add Yii2 config
+RUN { \
+        echo '<Directory /var/www/html/web>'; \
+        echo '  Require all granted'; \
+        echo '  # use mod_rewrite for pretty URL support'; \
+        echo '  RewriteEngine on'; \
+        echo '  # If a directory or a file exists, use the request directly'; \
+        echo '  RewriteCond %{REQUEST_FILENAME} !-f'; \
+        echo '  RewriteCond %{REQUEST_FILENAME} !-d'; \
+        echo '  # Exclude static file types'; \
+        echo '  RewriteCond %{REQUEST_URI} !\.(css|gif|ico|jpg|js|map|png|svg|ttf|woff|woff2)$'; \
+        echo '  # Otherwise forward the request to index.php'; \
+        echo '  RewriteRule . index.php'; \
+        echo '</Directory>'; \
+    } | tee /etc/apache2/conf-available/yii2-php.conf \
+    && sed -i 's#DocumentRoot.*#DocumentRoot /var/www/html/web#' /etc/apache2/sites-available/000-default.conf \
+    && sed -i 's/ServerTokens OS/ServerTokens Prod/' /etc/apache2/conf-available/security.conf \
+    && sed -i 's/ServerSignature On/ServerSignature Off/' /etc/apache2/conf-available/security.conf \
+    && a2enconf yii2-php \
+    && a2enmod rewrite
+
 # Install composer
 COPY install-composer /install-composer
 RUN /install-composer && rm /install-composer

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -24,6 +24,23 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 
+# Add Yii2 config
+RUN { \
+        echo '<Directory /var/www/html/web>'; \
+        echo '  Require all granted'; \
+        echo '  # use mod_rewrite for pretty URL support'; \
+        echo '  RewriteEngine on'; \
+        echo '  # If a directory or a file exists, use the request directly'; \
+        echo '  RewriteCond %{REQUEST_FILENAME} !-f'; \
+        echo '  RewriteCond %{REQUEST_FILENAME} !-d'; \
+        echo '  # Otherwise forward the request to index.php'; \
+        echo '  RewriteRule . index.php'; \
+        echo '</Directory>'; \
+    } | tee /etc/apache2/conf-available/yii2-php.conf \
+    && sed -i 's#DocumentRoot.*#DocumentRoot /var/www/html/web#' /etc/apache2/sites-available/000-default.conf \
+    && a2enconf yii2-php \
+    && a2enmod rewrite
+
 # Install composer
 COPY install-composer /install-composer
 RUN /install-composer && rm /install-composer

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -33,11 +33,15 @@ RUN { \
         echo '  # If a directory or a file exists, use the request directly'; \
         echo '  RewriteCond %{REQUEST_FILENAME} !-f'; \
         echo '  RewriteCond %{REQUEST_FILENAME} !-d'; \
+        echo '  # Exclude static file types'; \
+        echo '  RewriteCond %{REQUEST_URI} !\.(css|gif|ico|jpg|js|map|png|svg|ttf|woff|woff2)$'; \
         echo '  # Otherwise forward the request to index.php'; \
         echo '  RewriteRule . index.php'; \
         echo '</Directory>'; \
     } | tee /etc/apache2/conf-available/yii2-php.conf \
     && sed -i 's#DocumentRoot.*#DocumentRoot /var/www/html/web#' /etc/apache2/sites-available/000-default.conf \
+    && sed -i 's/ServerTokens OS/ServerTokens Prod/' /etc/apache2/conf-available/security.conf \
+    && sed -i 's/ServerSignature On/ServerSignature Off/' /etc/apache2/conf-available/security.conf \
     && a2enconf yii2-php \
     && a2enmod rewrite
 


### PR DESCRIPTION
I've used the same approach as in the official PHP image here:

https://github.com/docker-library/php/blob/master/7.1/apache/Dockerfile#L71

So there's a yii2 specific config file with the rewrite rules in `/etc/apache2/conf-available/yii2-php.conf` now. I also had to change the document root in the default host as Yii apps will usually be mapped/added to `/var/www/html` and the `index.php` is in `web/index.php`.

For custom configs a developer can still:

 * Override the above file by mapping his own `yii2-php.conf` into the container
 * Add extra configuration by mapping e.g. a `custom.conf` into the container's `/etc/apache2/conf-enabled`

If we can agree on this, I'd add the same approach for 5.6 and 7.0.