### PR TITLE
Improve cleanup after extensions installation

### DIFF
--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -2,6 +2,7 @@ FROM php:5.6.30-apache
 
 RUN apt-get update \
     && apt-get -y install \
+            libicu52 \
             libicu-dev \
 
             # Required by composer
@@ -11,7 +12,6 @@ RUN apt-get update \
 
     # Required extension
     && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) mbstring \
 
     # Additional common extensions
     && docker-php-ext-install -j$(nproc) opcache \
@@ -21,6 +21,10 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) zip \
 
     # Cleanup to keep the images size small
+    && apt-get purge -y \
+        icu-devtools \
+        libicu-dev \
+        zlib1g-dev \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -2,6 +2,7 @@ FROM php:5.6.30-fpm
 
 RUN apt-get update \
     && apt-get -y install \
+            libicu52 \
             libicu-dev \
 
             # Required by composer
@@ -11,7 +12,6 @@ RUN apt-get update \
 
     # Required extension
     && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) mbstring \
 
     # Additional common extensions
     && docker-php-ext-install -j$(nproc) opcache \
@@ -21,6 +21,10 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) zip \
 
     # Cleanup to keep the images size small
+    && apt-get purge -y \
+        icu-devtools \
+        libicu-dev \
+        zlib1g-dev \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.0.16-apache
 
 RUN apt-get update \
     && apt-get -y install \
+            libicu52 \
             libicu-dev \
 
             # Required by composer
@@ -11,7 +12,6 @@ RUN apt-get update \
 
     # Required extension
     && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) mbstring \
 
     # Additional common extensions
     && docker-php-ext-install -j$(nproc) opcache \
@@ -21,6 +21,10 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) zip \
 
     # Cleanup to keep the images size small
+    && apt-get purge -y \
+        icu-devtools \
+        libicu-dev \
+        zlib1g-dev \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.0.16-fpm
 
 RUN apt-get update \
     && apt-get -y install \
+            libicu52 \
             libicu-dev \
 
             # Required by composer
@@ -11,7 +12,6 @@ RUN apt-get update \
 
     # Required extension
     && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) mbstring \
 
     # Additional common extensions
     && docker-php-ext-install -j$(nproc) opcache \
@@ -21,6 +21,10 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) zip \
 
     # Cleanup to keep the images size small
+    && apt-get purge -y \
+        icu-devtools \
+        libicu-dev \
+        zlib1g-dev \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.1.2-apache
 
 RUN apt-get update \
     && apt-get -y install \
+            libicu52 \
             libicu-dev \
 
             # Required by composer
@@ -11,7 +12,6 @@ RUN apt-get update \
 
     # Required extension
     && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) mbstring \
 
     # Additional common extensions
     && docker-php-ext-install -j$(nproc) opcache \
@@ -21,6 +21,10 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) zip \
 
     # Cleanup to keep the images size small
+    && apt-get purge -y \
+        icu-devtools \
+        libicu-dev \
+        zlib1g-dev \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.1.2-fpm
 
 RUN apt-get update \
     && apt-get -y install \
+            libicu52 \
             libicu-dev \
 
             # Required by composer
@@ -11,7 +12,6 @@ RUN apt-get update \
 
     # Required extension
     && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) mbstring \
 
     # Additional common extensions
     && docker-php-ext-install -j$(nproc) opcache \
@@ -21,6 +21,10 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) zip \
 
     # Cleanup to keep the images size small
+    && apt-get purge -y \
+        icu-devtools \
+        libicu-dev \
+        zlib1g-dev \
     && apt-get autoremove -y \
     && rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
This shrinks the image size by ca. 40 MB:

* dev libs are only required for building the extensions
* mbstring seems to be installed by default in PHP for some time now

What's left:
* git pulls in ugly 30 MB of stuff. I've added it because I think composer needs it - but I'm not really sure.

@schmunk42 I did a quick local test and it looked good. Can you verify that this also doesn't break anything for you?