### PR TITLE
Implement web based tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+tests/yii2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,32 @@ language: bash
 services: docker
 
 env:
-  - VERSION=7.1 VARIANT=apache
-  - VERSION=7.1 VARIANT=fpm
-  - VERSION=7.0 VARIANT=apache
-  - VERSION=7.0 VARIANT=fpm
-  - VERSION=5.6 VARIANT=apache
-  - VERSION=5.6 VARIANT=fpm
+  - VERSION=7.1 VARIANT=apache TYPE=http
+  - VERSION=7.1 VARIANT=fpm TYPE=fcgi
+  - VERSION=7.0 VARIANT=apache TYPE=http
+  - VERSION=7.0 VARIANT=fpm TYPE=fcgi
+  - VERSION=5.6 VARIANT=apache TYPE=http
+  - VERSION=5.6 VARIANT=fpm TYPE=fcgi
 
-install: true
+install:
+  - git clone https://github.com/yiisoft/yii2.git ~/build/yiisoft/yii2-docker/tests/yii2
+  - sudo apt-get install libfcgi0ldbl
 
 before_script:
+  - pwd
   - cd "$VERSION"
   - image="yii2-php:${VERSION}${VARIANT:+-$VARIANT}"
   - image="${image//'/'/-}"
 
 script:
-  - travis_retry docker build -t "$image" "${VARIANT:-.}"
-  # TODO: Write actual test script that runs Yii requirement
-  # checker for each image, e.g.:
-  # - tests/run.sh "$image" "$VARIANT"
+  # Build min image
+  - travis_retry docker build -t "$image" "$VARIANT"
+  # TODO: Build other flavours
+  #- travis_retry docker build -t "{$image}-common" -f Dockerfile.common "$VARIANT"
+  - cd ~/build/yiisoft/yii2-docker/tests
+  - travis_retry ./run.sh "$image" "$TYPE" min
+  # TODO: Test other flavours
+  #- travis_retry ./run.sh "$image-common" "$TYPE" common
 
 after_script:
   - docker images

--- a/tests/requirements-common.php
+++ b/tests/requirements-common.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * These are the requirements for the yii2-php:*-common docker image.
+ * Note: You don't need to inlcude yii2's core requirements again here.
+ */
+
+/* @var $this YiiRequirementChecker */
+return array(
+    array(
+        'name' => 'APC extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('apcu'),
+    ),
+    array(
+        'name' => 'Fileinfo extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('fileinfo'),
+    ),
+    array(
+        'name' => 'Intl extension',
+        'mandatory' => true,
+        'condition' => $this->checkPhpExtensionVersion('intl', '1.0.2', '>='),
+    ),
+    array(
+        'name' => 'ICU version',
+        'mandatory' => true,
+        'condition' => defined('INTL_ICU_VERSION') && version_compare(INTL_ICU_VERSION, '49', '>='),
+    ),
+    array(
+        'name' => 'ICU Data version',
+        'mandatory' => true,
+        'condition' => defined('INTL_ICU_DATA_VERSION') && version_compare(INTL_ICU_DATA_VERSION, '49.1', '>='),
+    ),
+    array(
+        'name' => 'Opcache extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('Zend OPcache'),
+    ),
+    array(
+        'name' => 'PDO extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('pdo'),
+    ),
+    array(
+        'name' => 'PDO MySQL extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('pdo_mysql'),
+    ),
+);

--- a/tests/requirements-min.php
+++ b/tests/requirements-min.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * These are the requirements for the yii2-php:*-min docker image.
+ * Note: You don't need to inlcude yii2's core requirements again here.
+ */
+
+/* @var $this YiiRequirementChecker */
+return array(
+    array(
+        'name' => 'APC extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('apcu'),
+    ),
+    array(
+        'name' => 'Fileinfo extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('fileinfo'),
+    ),
+    array(
+        'name' => 'Intl extension',
+        'mandatory' => true,
+        'condition' => $this->checkPhpExtensionVersion('intl', '1.0.2', '>='),
+    ),
+    array(
+        'name' => 'ICU version',
+        'mandatory' => true,
+        'condition' => defined('INTL_ICU_VERSION') && version_compare(INTL_ICU_VERSION, '49', '>='),
+    ),
+    array(
+        'name' => 'ICU Data version',
+        'mandatory' => true,
+        'condition' => defined('INTL_ICU_DATA_VERSION') && version_compare(INTL_ICU_DATA_VERSION, '49.1', '>='),
+    ),
+    array(
+        'name' => 'Opcache extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('Zend OPcache'),
+    ),
+);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Use like:
+#
+#     ./run.sh <image> <type:(http|fcgi)> <flavour:(min|common)>
+
+if [ -z $1 ]; then
+    echo 'No image supplied'
+    exit 1
+fi
+if [ -z $2 ]; then
+    echo 'No type supplied'
+    exit 1
+fi
+if [ -z $3 ]; then
+    echo 'No flavour supplied'
+    exit 1
+fi
+
+echo "testing $1"
+
+if [ $3 = "min" ]; then
+    QUERY='flavour=min'
+elif [ $3 = "common" ]; then
+    QUERY='flavour=common'
+else
+    echo >&2 "Invalid flavour $3"
+    exit 1
+fi
+
+
+if [ $2 = "http" ]; then
+    ID=$(docker run -d -p 80:80 -v $PWD:/var/www/html --name test $1)
+    sleep 3
+    RESULT=$(curl -s "http://localhost/checker.php?$QUERY")
+elif [ $2 = "fcgi" ]; then
+    ID=$(docker run -d -p 9000:9000 -v $PWD:/var/www/html --name test $1)
+    sleep 3
+    RESULT=$(REQUEST_METHOD=GET \
+        SCRIPT_NAME="checker.php" \
+        SCRIPT_FILENAME='/var/www/html/web/checker.php' \
+        QUERY_STRING="$QUERY" \
+        cgi-fcgi -bind -connect 127.0.0.1:9000 | tail -1)
+else
+    echo >&2 "Invalid type $2"
+    exit 1
+fi
+
+if [ "$RESULT" != "OK" ]; then
+    echo >&2 "failed"
+    echo >&2 "$RESULT"
+    $(docker stop test)
+    $(docker rm test)
+    exit 1
+fi
+
+$(docker stop test)
+$(docker rm test)
+echo "passed"
+exit 0

--- a/tests/web/checker.php
+++ b/tests/web/checker.php
@@ -1,0 +1,17 @@
+<?php
+require_once(__DIR__ . '/../yii2/framework/requirements/YiiRequirementChecker.php');
+
+$flavour = isset($_GET['flavour']) ? $_GET['flavour'] : 'min';
+
+$result = (new YiiRequirementChecker())
+    ->checkYii()
+    ->check(__DIR__ . "/../requirements-$flavour.php")
+    ->getResult();
+
+foreach ($result['requirements'] as $requirement) {
+    if ($requirement['error']) {
+        echo "MISSING: $requirement[name]";
+        exit;
+    }
+}
+echo 'OK';


### PR DESCRIPTION
An alternative test implementation.

 * Tests via HTTP and FastCGI
 * New tests only require update of `env` in `.travis.yml`
 * Requirements for each flavour can be specified in `tests/requirements-<flavour>.php`