### PR TITLE
Additional optimizations to alpine images

### DIFF
--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -4,24 +4,19 @@ RUN apk add --update --no-cache \
         # Runtime dependencies
         icu-libs \
         libpng \
-        jpeg \
+        libjpeg-turbo \
         freetype \
     && apk add --update --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
         # Build dependencies (will be removed after extensions are built)
         icu-dev \
-        jpeg-dev \
         libjpeg-turbo-dev \
         libpng-dev \
         freetype-dev \
-        # Required for APC
-        autoconf \
-        gcc \
-        g++ \
-        make \
     && pecl install apcu-4.0.11 \
     && docker-php-ext-enable apcu \
     && docker-php-ext-configure \
-        gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+        gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ \
     && docker-php-ext-install \
         # Required extensions
         intl \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -4,24 +4,19 @@ RUN apk add --update --no-cache \
         # Runtime dependencies
         icu-libs \
         libpng \
-        jpeg \
+        libjpeg-turbo \
         freetype \
     && apk add --update --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
         # Build dependencies (will be removed after extensions are built)
         icu-dev \
-        jpeg-dev \
         libjpeg-turbo-dev \
         libpng-dev \
         freetype-dev \
-        # Required for APC
-        autoconf \
-        gcc \
-        g++ \
-        make \
     && pecl install apcu \
     && docker-php-ext-enable apcu \
     && docker-php-ext-configure \
-        gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+        gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ \
     && docker-php-ext-install \
         # Required extensions
         intl \

--- a/7.1/fpm/alpine/Dockerfile
+++ b/7.1/fpm/alpine/Dockerfile
@@ -4,24 +4,19 @@ RUN apk add --update --no-cache \
         # Runtime dependencies
         icu-libs \
         libpng \
-        jpeg \
+        libjpeg-turbo \
         freetype \
     && apk add --update --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
         # Build dependencies (will be removed after extensions are built)
         icu-dev \
-        jpeg-dev \
         libjpeg-turbo-dev \
         libpng-dev \
         freetype-dev \
-        # Required for APC
-        autoconf \
-        gcc \
-        g++ \
-        make \
     && pecl install apcu \
     && docker-php-ext-enable apcu \
     && docker-php-ext-configure \
-        gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+        gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ \
     && docker-php-ext-install \
         # Required extensions
         intl \


### PR DESCRIPTION
I've incorporated additional optimizations to alpine images from our private repo:

- First of all you don't need `jpeg` package for `gd`, `libjpeg-turbo` is smaller and is enough
- Second there's already ENV var in parent php images that defines all build dependencies for php extensions
- And third you install `libpng` but didn't configure `gd` with png support