### PR TITLE
Remove apache settings from alpine images

### DIFF
--- a/php/Dockerfile-alpine
+++ b/php/Dockerfile-alpine
@@ -92,9 +92,5 @@ RUN composer global require --optimize-autoloader \
     composer global dumpautoload --optimize && \
     composer clear-cache
 
-# Enable mod_rewrite for images with apache
-RUN if command -v a2enmod >/dev/null 2>&1; \
-    then a2enmod rewrite; fi
-
 # Application environment
 WORKDIR /app


### PR DESCRIPTION
> It's only for Apache, which is only available on Debian (in official Docker images) AFAIK.