### PR TITLE
apt-get update removal

### DIFF
--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get -y install \
         gnupg2 && \
     apt-key update && \
-    apt-get update && \
+#    apt-get update && \    this is deprecated and should be removed?
     apt-get -y install \
             g++ \
             git \


### PR DESCRIPTION
I received a message stating the "apt-get update" is deprecated and should be removed during the build.