### PR TITLE
Xdebug for mac specifications

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -9,7 +9,7 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.apache.yml
 DOCKERFILE_FLAVOUR=debian
 PHP_BASE_IMAGE_VERSION=7.2-apache
 
-# Xdebug (calling the 10.254.254.254 on 9005 port)
+# Xdebug (calling the xdebug.remote_host on 9005 port)
 PHP_ENABLE_XDEBUG=0
 
 ## PHP-fpm & nginx

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The `Dockerfile`(s) of this repository are designed to build from different PHP-
 ## Setup
 
     cp .env-dist .env
-    
-Adjust the versions in `.env` if you want to build a specific version. 
+
+Adjust the versions in `.env` if you want to build a specific version.
 
 > **Note:** Please make sure to use a matching combination of `DOCKERFILE_FLAVOUR` and `PHP_BASE_IMAGE_VERSION`
 
@@ -54,12 +54,13 @@ Adjust the versions in `.env` if you want to build a specific version.
 
 To enable Xdebug, set `PHP_ENABLE_XDEBUG=1` in .env file
 
-Xdebug is configured to call ip 10.254.254.254 on 9005 port (not use standard port to avoid conflicts),
+Xdebug is configured to call ip `xdebug.remote_host` on `9005` port (not use standard port to avoid conflicts),
 so you have to configure your IDE to receive connections from that ip.
 
-The port 9005 is enabled in docker-compose.apache.yml and to activate ip 10.254.254.254 locally, on MacOS the command is: 
+If you are using macOS, you can fill `xdebug.remote_host` with `host.docker.internal`, due to a network limitation on mac (https://docs.docker.com/docker-for-mac/networking/#port-mapping)
 
-    ifconfig lo0 alias 10.254.254.254
+    ### (macOS) configuration
+    xdebug.remote_host=host.docker.internal
 
 ## Documentation
 

--- a/docker-compose.apache.yml
+++ b/docker-compose.apache.yml
@@ -4,4 +4,3 @@ services:
   php:
     ports:
       - '8000:80'
-      - '9005:9005'     # comment it if you don't use Xdebug

--- a/php/image-files/usr/local/etc/php/conf.d/xdebug.ini
+++ b/php/image-files/usr/local/etc/php/conf.d/xdebug.ini
@@ -2,10 +2,9 @@
 xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=0
-;;; using default localhost ip inside docker
-;;; remember to create an alias of lo0 with: ifconfig lo0 alias 10.254.254.254
-xdebug.remote_host=10.254.254.254
+;;; if you are on macOS, use host.docker.internal to identify the host machine, due to a network limitation on mac (https://docs.docker.com/docker-for-mac/networking/#port-mapping)
+;;; otherwise find host ip
+xdebug.remote_host=host.docker.internal
 ;;; avoid standard port (9000) conflicts using 9005 port
 xdebug.remote_port=9005
 xdebug.idekey=PHPStorm
-xdebug.extended_info=1


### PR DESCRIPTION
- Removed unuseful ipaddress for xdebug.remote_host on macOS
- Removed port 9005 from exposed php service ports (unuseful because container uses it to connect to remote host)
- Updated readme with new Xdebug specification