### PR TITLE
folder symlink is wrong

### DIFF
--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -104,7 +104,7 @@ RUN composer global require --optimize-autoloader \
     composer clear-cache
 
 # Create a symlink for apache (if `/var/www/html` is available)
-RUN (rm -rf /var/www/html && mkdir /var/www/html && ln -s /app/web/ /var/www/html) || true
+RUN (rm -rf /var/www/html && ln -s /app/web/ /var/www/html) || true
 
 # Enable mod_rewrite for images with apache
 RUN if command -v a2enmod >/dev/null 2>&1; then \


### PR DESCRIPTION
Creating the folder first and then setting the folder link to /app/web creates the folder /var/www/html/web. I don't think that's intended, since with this change the app is served with the url http://localhost/web