### PR TITLE
Added ssl packages for MongoDB 4.0

### DIFF
--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -32,6 +32,8 @@ RUN apt-get update && \
             openssh-client \
             nano \
             unzip \
+            libcurl4-openssl-dev \
+            libssl-dev \
         --no-install-recommends && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This fixes the problem of connecting to MongoDB 4.0.
Error Message:
"The SCRAM_SHA_256 authentication mechanism requires libmongoc created with ENABLE_SSL" 
or
"The SCRAM_SHA_1 authentication mechanism requires libmongoc created with ENABLE_SSL" 

View: https://docs.mongodb.com/manual/reference/connection-string/#urioption.authMechanism