### PR TITLE
xdebug should be disabled by default

### DIFF
--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -73,7 +73,6 @@ RUN printf "\n" | pecl install \
         mongodb && \
     docker-php-ext-enable \
         imagick \
-        xdebug \
         mongodb
 
 # Environment settings


### PR DESCRIPTION
Woops, I forgot xdebug should only be enabled when `PHP_ENABLE_XDEBUG=0`.  Maybe a test should cover that in the future?