### PR TITLE
remove deprecated xdebug configuration keys

### DIFF
--- a/php/image-files/usr/local/etc/php/conf.d/xdebug.ini
+++ b/php/image-files/usr/local/etc/php/conf.d/xdebug.ini
@@ -1,8 +1,6 @@
 ;zend_extension=xdebug.so
-xdebug.remote_enable=1
-xdebug.remote_autostart=1
-xdebug.remote_connect_back=0
 xdebug.mode=debug
+xdebug.start_with_request=yes
 ;;; if you are on macOS, use host.docker.internal to identify the host machine, due to a network limitation on mac (https://docs.docker.com/docker-for-mac/networking/#port-mapping)
 ;;; otherwise find host ip
 xdebug.client_host=host.docker.internal


### PR DESCRIPTION
to remove warnings from console

https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_enable
https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_autostart
https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_connect_back