### PR TITLE
Update composer version

### DIFF
--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -43,7 +43,6 @@ RUN chmod 755 \
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- \
-        --version=2.1.3 \
         --filename=composer.phar \
         --install-dir=/usr/local/bin && \
     composer clear-cache


### PR DESCRIPTION
There is another security issue for composer fixed: https://github.com/composer/composer/releases/tag/2.1.9

To skip the need to update this file every time something like this happens I think we can remove the specific version requirement. If this is needed we should bump this to 2.1.9.