### PR TITLE
GitLab (gitlab.com) access token support

### DIFF
--- a/php/image-files/dev/usr/local/bin/composer
+++ b/php/image-files/dev/usr/local/bin/composer
@@ -7,4 +7,9 @@ then
     composer.phar config -g github-oauth.github.com ${GITHUB_API_TOKEN}
 fi
 
+if [ -n "${GITLAB_ACCESS_TOKEN}" ]
+then
+    composer.phar config -g gitlab-token.gitlab.com ${GITLAB_ACCESS_TOKEN}
+fi
+
 composer.phar "$@"


### PR DESCRIPTION
Add GitLab (gitlab.com) access token support for composer packages hosted in GitLab (gitlab.com).